### PR TITLE
Cleanup: Removed unnessesary code.

### DIFF
--- a/src/css/scope-css.ts
+++ b/src/css/scope-css.ts
@@ -1,7 +1,6 @@
 import {
   parse,
   generate,
-  SelectorList,
   AttributeSelector,
   StyleSheet,
   CssNode,
@@ -92,22 +91,15 @@ export function scopeCss(css: string, filename: string, hash: string) {
           return;
         }
 
-        let hasHitDeep = false;
         let item = (selector.children as LinkedList).head;
 
-        while (item !== null || hasHitDeep) {
-          // Only to satisfy typescript
-          if (item === null) {
-            break;
-          }
-
+        while (item !== null) {
           if (isScopedAttributeSelector(item, hash)) {
             item = item?.next ?? null;
             continue;
           }
 
           if (item.next && isScopePiercingPseudoSelector(item.next)) {
-            hasHitDeep = true;
             Object.assign(item.next.data, attributeSelector);
             break;
           }


### PR DESCRIPTION
* `hasHitDeep` is not needed as the only time it's changed we break the loop. It will always be false.
* Typecheck if item is null is not needed as typescript figures that out from the loop. Checked both through linting in terminal and in editor. If you are experiencing issues, maybe update Typescript/eslint in your editor or something?
* SelectorList type is no longer used since your refactor, let's get rid of the import :)