### PR TITLE
CSS Scoping: Improved tests and readability of scoping logic.

### DIFF
--- a/src/css/scope-css.spec.ts
+++ b/src/css/scope-css.spec.ts
@@ -9,225 +9,267 @@ const validateCss = (inputCss, expectedScopedCss) => {
 };
 
 describe("scope-css", () => {
-  it("scopes basic classes and elements", () => {
-    validateCss(
-      ".content-container { width: 962px; } div { background: green; }",
-      ".content-container[data-123456] { width: 962px; } div[data-123456] { background: green; }"
-    );
-  });
-
-  it("scopes adjecent sibiling selectors correctly", () => {
-    validateCss(
-      "h4 + p { color: green; }",
-      "h4[data-123456] + p[data-123456] { color: green; }"
-    );
-  });
-
-  it("scopes child selectors correctly", () => {
-    validateCss(
-      "p > em { color: green; }",
-      "p[data-123456] > em[data-123456] { color: green; }"
-    );
-  });
-
-  it("scopes child selectors correctly with deep", () => {
-    validateCss(
-      "p::deep > em { color: green; }",
-      "p[data-123456] > em { color: green; }"
-    );
-  });
-
-  it("scopes susequent selectors correctly", () => {
-    validateCss(
-      "p ~ em { color: green; }",
-      "p[data-123456] ~ em[data-123456] { color: green; }"
-    );
-  });
-
-  it("scopes susequent selectors correctly with deep", () => {
-    validateCss(
-      "p::deep ~ em { color: green; }",
-      "p[data-123456] ~ em { color: green; }"
-    );
-  });
-
-  it("scopes selectors chain with deep correctly", () => {
-    validateCss(
-      "div.class1::deep.class2 { color: gold; }",
-      "div.class1[data-123456].class2 { color: gold; }"
-    );
-  });
-
-  it("scopes selectors chain with pseudo selectors in weird order", () => {
-    validateCss(
-      "a.anchor:active.class2 { color: pink; }",
-      "a.anchor[data-123456]:active.class2[data-123456] { color: pink; }"
-    );
-  });
-
-  it("scopes selectors chain with pseudo selectors with lots of chain", () => {
-    validateCss(
-      ".tire .eu-labels .eu-label span:not(.skeleton-image):not(.extra)::before { color: purple; }",
-      ".tire[data-123456] .eu-labels[data-123456] .eu-label[data-123456] span[data-123456]:not(.skeleton-image):not(.extra)::before { color: purple; }"
-    );
-  });
-
-  it("scopes id selectors correctly", () => {
-    validateCss(
-      "#content { border: 2px solid green; }",
-      "#content[data-123456] { border: 2px solid green; }"
-    );
-    validateCss(
-      "div#blue-box { border: 2px solid blue; }",
-      "div#blue-box[data-123456] { border: 2px solid blue; }"
-    );
-    validateCss(
-      "div#blue-box.block { border: 2px solid blue; }",
-      "div#blue-box.block[data-123456] { border: 2px solid blue; }"
-    );
-  });
-
-  it("scopes all non-pseudo selector", () => {
-    validateCss(
-      "div.content-container .button { cursor: crosshair; }",
-      "div.content-container[data-123456] .button[data-123456] { cursor: crosshair; }"
-    );
-  });
-
-  it("scopes at ::deep selector and not deeper", () => {
-    validateCss(
-      ".content-container::deep span.nested { color: pink; }",
-      ".content-container[data-123456] span.nested { color: pink; }"
-    );
-  });
-
-  it("scopes at ::deep selector and not deeper using v-deep syntax", () => {
-    validateCss(
-      ".content-container::v-deep .nested2 { color: yellow; }",
-      ".content-container[data-123456] .nested2 { color: yellow; }"
-    );
-  });
-
-  it("scopes multiple selector-lists", () => {
-    validateCss(
-      "div .button, div .button span { border-radius: 4px; }",
-      "div[data-123456] .button[data-123456], div[data-123456] .button[data-123456] span[data-123456] { border-radius: 4px; }"
-    );
-  });
-
-  it("scopes multiple selector-lists with and without ::deep selector", () => {
-    validateCss(
-      "div .button, div .button::deep span { border-radius: 4px; }",
-      "div[data-123456] .button[data-123456], div[data-123456] .button[data-123456] span { border-radius: 4px; }"
-    );
-
-    validateCss(
-      ".content-container::deep span.nested, .button span { color: pink; }",
-      ".content-container[data-123456] span.nested, .button[data-123456] span[data-123456] { color: pink; }"
-    );
-  });
-
-  it("scopes even with other data-selectors pressent", () => {
-    validateCss(
-      'div.container[data-x="test"] { color:green; }',
-      'div.container[data-x="test"][data-123456] { color:green; }'
-    );
-    validateCss(
-      '.block div.container[data-x="test"] { color:green; }',
-      '.block[data-123456] div.container[data-x="test"][data-123456] { color:green; }'
-    );
-  });
-
-  describe("using media queries", () => {
+  describe("Basic css", () => {
     it("scopes basic classes and elements", () => {
       validateCss(
-        "@media only screen and (max-width: 962px) { .content-container { width: 962px; } div { background: green; } }",
-        "@media only screen and (max-width: 962px) { .content-container[data-123456] { width: 962px; } div[data-123456] { background: green; } }"
+        ".content-container { width: 962px; } div { background: green; }",
+        ".content-container[data-123456] { width: 962px; } div[data-123456] { background: green; }"
       );
     });
 
     it("scopes adjecent sibiling selectors correctly", () => {
       validateCss(
-        "@media only screen and (max-width: 962px) { h4 + p { color: green; } }",
-        "@media only screen and (max-width: 962px) { h4[data-123456] + p[data-123456] { color: green; } }"
+        "h4 + p { color: green; }",
+        "h4[data-123456] + p[data-123456] { color: green; }"
       );
     });
 
     it("scopes child selectors correctly", () => {
       validateCss(
-        "@media only screen and (max-width: 962px) { p > em { color: green; } }",
-        "@media only screen and (max-width: 962px) { p[data-123456] > em[data-123456] { color: green; } }"
+        "p > em { color: green; }",
+        "p[data-123456] > em[data-123456] { color: green; }"
+      );
+    });
+
+    it("scopes susequent selectors correctly", () => {
+      validateCss(
+        "p ~ em { color: green; }",
+        "p[data-123456] ~ em[data-123456] { color: green; }"
       );
     });
 
     it("scopes id selectors correctly", () => {
       validateCss(
-        "@media only screen and (max-width: 962px) { #content { border: 2px solid green; } div#blue-box { border: 2px solid blue; } }",
-        "@media only screen and (max-width: 962px) { #content[data-123456] { border: 2px solid green; } div#blue-box[data-123456] { border: 2px solid blue; } }"
+        "#content { border: 2px solid green; }",
+        "#content[data-123456] { border: 2px solid green; }"
+      );
+      validateCss(
+        "div#blue-box { border: 2px solid blue; }",
+        "div#blue-box[data-123456] { border: 2px solid blue; }"
+      );
+      validateCss(
+        "div#blue-box.block { border: 2px solid blue; }",
+        "div#blue-box.block[data-123456] { border: 2px solid blue; }"
       );
     });
 
-    it("scopes all non-psuedo selectors", () => {
+    it("scopes all non-pseudo selector", () => {
       validateCss(
-        "@media only screen and (max-width: 962px) { div.content-container .button { cursor: crosshair; } }",
-        "@media only screen and (max-width: 962px) { div.content-container[data-123456] .button[data-123456] { cursor: crosshair; } }"
-      );
-    });
-
-    it("scopes at ::deep selector and not deeper", () => {
-      validateCss(
-        "@media only screen and (max-width: 962px) { .content-container::deep span.nested { color: pink; } }",
-        "@media only screen and (max-width: 962px) { .content-container[data-123456] span.nested { color: pink; } }"
-      );
-    });
-
-    it("scopes at ::deep selector and not deeper using v-deep syntax", () => {
-      validateCss(
-        "@media only screen and (max-width: 962px) { .content-container::v-deep .nested2 { color: yellow; } }",
-        "@media only screen and (max-width: 962px) { .content-container[data-123456] .nested2 { color: yellow; } }"
+        "div.content-container .button { cursor: crosshair; }",
+        "div.content-container[data-123456] .button[data-123456] { cursor: crosshair; }"
       );
     });
 
     it("scopes multiple selector-lists", () => {
       validateCss(
-        "@media only screen and (max-width: 962px) { div .button, div .button span { border-radius: 4px; } }",
-        "@media only screen and (max-width: 962px) { div[data-123456] .button[data-123456], div[data-123456] .button[data-123456] span[data-123456] { border-radius: 4px; } }"
+        "div .button, div .button span { border-radius: 4px; }",
+        "div[data-123456] .button[data-123456], div[data-123456] .button[data-123456] span[data-123456] { border-radius: 4px; }"
       );
     });
 
     it("scopes even with other data-selectors pressent", () => {
       validateCss(
-        '@media only screen and (max-width: 962px) { div.container[data-x="test"] { color:green; } }',
-        '@media only screen and (max-width: 962px) { div.container[data-x="test"][data-123456] { color:green; } }'
+        'div.container[data-x="test"] { color:green; }',
+        'div.container[data-x="test"][data-123456] { color:green; }'
+      );
+      validateCss(
+        '.block div.container[data-x="test"] { color:green; }',
+        '.block[data-123456] div.container[data-x="test"][data-123456] { color:green; }'
+      );
+    });
+  });
+
+  describe("Deep selectors", () => {
+    it("scopes child selectors correctly with deep", () => {
+      validateCss(
+        "p::deep > em { color: green; }",
+        "p[data-123456] > em { color: green; }"
+      );
+    });
+
+    it("scopes susequent selectors correctly with deep", () => {
+      validateCss(
+        "p::deep ~ em { color: green; }",
+        "p[data-123456] ~ em { color: green; }"
+      );
+    });
+
+    it("scopes selectors chain with deep correctly", () => {
+      validateCss(
+        "div.class1::deep.class2 { color: gold; }",
+        "div.class1[data-123456].class2 { color: gold; }"
+      );
+    });
+
+    it("scopes at ::deep selector and not deeper", () => {
+      validateCss(
+        ".content-container::deep span.nested { color: pink; }",
+        ".content-container[data-123456] span.nested { color: pink; }"
+      );
+    });
+
+    it("scopes at ::deep selector and not deeper using v-deep syntax", () => {
+      validateCss(
+        ".content-container::v-deep .nested2 { color: yellow; }",
+        ".content-container[data-123456] .nested2 { color: yellow; }"
       );
     });
 
     it("scopes multiple selector-lists with and without ::deep selector", () => {
       validateCss(
-        "@media only screen and (max-width: 962px) { div .button, div .button::deep span { border-radius: 4px; } }",
-        "@media only screen and (max-width: 962px) { div[data-123456] .button[data-123456], div[data-123456] .button[data-123456] span { border-radius: 4px; } }"
+        "div .button, div .button::deep span { border-radius: 4px; }",
+        "div[data-123456] .button[data-123456], div[data-123456] .button[data-123456] span { border-radius: 4px; }"
+      );
+
+      validateCss(
+        ".content-container::deep span.nested, .button span { color: pink; }",
+        ".content-container[data-123456] span.nested, .button[data-123456] span[data-123456] { color: pink; }"
+      );
+    });
+  });
+
+  describe("Pseudo selectors", () => {
+    it("scopes selectors chain with pseudo selectors in weird order", () => {
+      validateCss(
+        "a.anchor:active.class2 { color: pink; }",
+        "a.anchor[data-123456]:active.class2[data-123456] { color: pink; }"
       );
     });
 
-    it("scopes with multiple media query conditions", () => {
+    it("scopes selectors chain with pseudo selectors with lots of chain", () => {
       validateCss(
-        "@media only screen and (min-width: 480px) and (max-width: 962px) { .content-container { width: 962px; } div { background: green; } }",
-        "@media only screen and (min-width: 480px) and (max-width: 962px) { .content-container[data-123456] { width: 962px; } div[data-123456] { background: green; } }"
+        ".block span:not(.skeleton-image):not(.extra)::before { color: purple; }",
+        ".block[data-123456] span[data-123456]:not(.skeleton-image):not(.extra)::before { color: purple; }"
       );
     });
 
-    it("scopes with multiple media query conditions using or", () => {
+    it("scopes selectors chain with pseudo selectors and classes at the end", () => {
       validateCss(
-        "@media only screen and (min-width: 480px), tv and (max-width: 962px) { .content-container { width: 962px; } div { background: green; } }",
-        "@media only screen and (min-width: 480px), tv and (max-width: 962px) { .content-container[data-123456] { width: 962px; } div[data-123456] { background: green; } }"
+        ".block span:hover.win { color: green; }",
+        ".block[data-123456] span[data-123456]:hover.win[data-123456] { color: green; }"
       );
     });
+  });
 
-    it("scopes with recursive media query", () => {
-      validateCss(
-        "@media (min-width: 480px) { @media (min-width: 240px) { .content-container { width: 962px; } div { background: green; } } }",
-        "@media (min-width: 480px) { @media (min-width: 240px) { .content-container[data-123456] { width: 962px; } div[data-123456] { background: green; } } }"
-      );
+  describe("Using media queries", () => {
+    describe("Basic css", () => {
+      it("scopes basic classes and elements", () => {
+        validateCss(
+          "@media only screen and (max-width: 962px) { .content-container { width: 962px; } div { background: green; } }",
+          "@media only screen and (max-width: 962px) { .content-container[data-123456] { width: 962px; } div[data-123456] { background: green; } }"
+        );
+      });
+
+      it("scopes adjecent sibiling selectors correctly", () => {
+        validateCss(
+          "@media only screen and (max-width: 962px) { h4 + p { color: green; } }",
+          "@media only screen and (max-width: 962px) { h4[data-123456] + p[data-123456] { color: green; } }"
+        );
+      });
+
+      it("scopes child selectors correctly", () => {
+        validateCss(
+          "@media only screen and (max-width: 962px) { p > em { color: green; } }",
+          "@media only screen and (max-width: 962px) { p[data-123456] > em[data-123456] { color: green; } }"
+        );
+      });
+
+      it("scopes id selectors correctly", () => {
+        validateCss(
+          "@media only screen and (max-width: 962px) { #content { border: 2px solid green; } div#blue-box { border: 2px solid blue; } }",
+          "@media only screen and (max-width: 962px) { #content[data-123456] { border: 2px solid green; } div#blue-box[data-123456] { border: 2px solid blue; } }"
+        );
+      });
+
+      it("scopes all non-psuedo selectors", () => {
+        validateCss(
+          "@media only screen and (max-width: 962px) { div.content-container .button { cursor: crosshair; } }",
+          "@media only screen and (max-width: 962px) { div.content-container[data-123456] .button[data-123456] { cursor: crosshair; } }"
+        );
+      });
+
+      it("scopes multiple selector-lists", () => {
+        validateCss(
+          "@media only screen and (max-width: 962px) { div .button, div .button span { border-radius: 4px; } }",
+          "@media only screen and (max-width: 962px) { div[data-123456] .button[data-123456], div[data-123456] .button[data-123456] span[data-123456] { border-radius: 4px; } }"
+        );
+      });
+
+      it("scopes even with other data-selectors pressent", () => {
+        validateCss(
+          '@media only screen and (max-width: 962px) { div.container[data-x="test"] { color:green; } }',
+          '@media only screen and (max-width: 962px) { div.container[data-x="test"][data-123456] { color:green; } }'
+        );
+      });
+    });
+
+    describe("Deep selectors", () => {
+      it("scopes at ::deep selector and not deeper", () => {
+        validateCss(
+          "@media only screen and (max-width: 962px) { .content-container::deep span.nested { color: pink; } }",
+          "@media only screen and (max-width: 962px) { .content-container[data-123456] span.nested { color: pink; } }"
+        );
+      });
+
+      it("scopes at ::deep selector and not deeper using v-deep syntax", () => {
+        validateCss(
+          "@media only screen and (max-width: 962px) { .content-container::v-deep .nested2 { color: yellow; } }",
+          "@media only screen and (max-width: 962px) { .content-container[data-123456] .nested2 { color: yellow; } }"
+        );
+      });
+
+      it("scopes multiple selector-lists with and without ::deep selector", () => {
+        validateCss(
+          "@media only screen and (max-width: 962px) { div .button, div .button::deep span { border-radius: 4px; } }",
+          "@media only screen and (max-width: 962px) { div[data-123456] .button[data-123456], div[data-123456] .button[data-123456] span { border-radius: 4px; } }"
+        );
+      });
+    });
+
+    describe("Pseudo selectors", () => {
+      it("scopes selectors chain with pseudo selectors in weird order", () => {
+        validateCss(
+          "@media only screen and (max-width: 962px) { a.anchor:active.class2 { color: pink; } }",
+          "@media only screen and (max-width: 962px) { a.anchor[data-123456]:active.class2[data-123456] { color: pink; } }"
+        );
+      });
+
+      it("scopes selectors chain with pseudo selectors with lots of chain", () => {
+        validateCss(
+          "@media only screen and (max-width: 962px) { .block span:not(.skeleton-image):not(.extra)::before { color: purple; } }",
+          "@media only screen and (max-width: 962px) { .block[data-123456] span[data-123456]:not(.skeleton-image):not(.extra)::before { color: purple; } }"
+        );
+      });
+
+      it("scopes selectors chain with pseudo selectors and classes at the end", () => {
+        validateCss(
+          ".block span:hover.win { color: green; }",
+          ".block[data-123456] span[data-123456]:hover.win[data-123456] { color: green; }"
+        );
+      });
+    });
+
+    describe("Advanced media query cases", () => {
+      it("scopes with multiple media query conditions", () => {
+        validateCss(
+          "@media only screen and (min-width: 480px) and (max-width: 962px) { .content-container { width: 962px; } div { background: green; } }",
+          "@media only screen and (min-width: 480px) and (max-width: 962px) { .content-container[data-123456] { width: 962px; } div[data-123456] { background: green; } }"
+        );
+      });
+
+      it("scopes with multiple media query conditions using or", () => {
+        validateCss(
+          "@media only screen and (min-width: 480px), tv and (max-width: 962px) { .content-container { width: 962px; } div { background: green; } }",
+          "@media only screen and (min-width: 480px), tv and (max-width: 962px) { .content-container[data-123456] { width: 962px; } div[data-123456] { background: green; } }"
+        );
+      });
+
+      it("scopes with recursive media query", () => {
+        validateCss(
+          "@media (min-width: 480px) { @media (min-width: 240px) { .content-container { width: 962px; } div { background: green; } } }",
+          "@media (min-width: 480px) { @media (min-width: 240px) { .content-container[data-123456] { width: 962px; } div[data-123456] { background: green; } } }"
+        );
+      });
     });
   });
 });

--- a/src/css/scope-css.ts
+++ b/src/css/scope-css.ts
@@ -22,6 +22,8 @@ interface LinkedList<T = CssNode> extends List<T> {
   tail: LinkedListNode<T> | null;
 }
 
+type ItemArray = Array<LinkedListNode>;
+
 const getSelectors = (items: List<CssNode>): LinkedList[] => {
   const selectorLists = items.reduce((acc, node) => {
     if (node.type === "Rule" && node?.prelude?.type === "SelectorList") {
@@ -50,43 +52,10 @@ const isScopePiercingPseudoSelector = (item: ListItem<CssNode>) => {
   );
 };
 
-const isThisScopedAttributeSelector = (
-  item: ListItem<CssNode>,
-  hash: string
-) => {
-  return (
-    item?.data?.type === "AttributeSelector" && item?.data?.name?.name === hash
-  );
-};
-
-const isChainedSelector = (item: ListItem<CssNode>) => {
-  return (
-    (item?.data?.type === "TypeSelector" ||
-      item?.data?.type === "ClassSelector" ||
-      item?.data?.type === "AttributeSelector" ||
-      item?.data?.type === "IdSelector" ||
-      item?.data?.type === "PseudoClassSelector" ||
-      item?.data?.type === "PseudoElementSelector") &&
-    (item?.next?.data?.type === "ClassSelector" ||
-      item?.next?.data?.type === "AttributeSelector" ||
-      item?.next?.data?.type === "IdSelector" ||
-      item?.next?.data?.type === "PseudoClassSelector" ||
-      item?.next?.data?.type === "PseudoElementSelector")
-  );
-};
-
 const isPseudoSelector = (item: ListItem<CssNode>) => {
   return (
     item?.data?.type === "PseudoClassSelector" ||
     item?.data?.type === "PseudoElementSelector"
-  );
-};
-
-const isNextItemScopable = (item: ListItem<CssNode>) => {
-  return (
-    item?.next?.data?.type === "ClassSelector" ||
-    item?.next?.data?.type === "AttributeSelector" ||
-    item?.next?.data?.type === "IdSelector"
   );
 };
 
@@ -115,30 +84,31 @@ export function scopeCss(css: string, filename: string, hash: string) {
 
         let item = (selector.children as LinkedList).head;
 
+        const itemsToInsertScopeBefore: ItemArray = [];
+        let currentChunkIndex = 0;
+
         while (item !== null) {
-          if (
-            (isChainedSelector(item) && isNextItemScopable(item)) ||
-            isCombinator(item) ||
-            isPseudoSelector(item) ||
-            isThisScopedAttributeSelector(item, hash)
-          ) {
-            item = item?.next ?? null;
-            continue;
-          }
-
-          if (item.next && isScopePiercingPseudoSelector(item.next)) {
-            Object.assign(item.next.data, attributeSelector);
+          if (isScopePiercingPseudoSelector(item)) {
+            Object.assign(item.data, attributeSelector);
             break;
-          }
-
-          if (item?.next === null) {
+          } else if (isCombinator(item) || isPseudoSelector(item)) {
+            currentChunkIndex += 1;
+          } else if (item.next) {
+            itemsToInsertScopeBefore[currentChunkIndex] = item.next;
+          } else {
             selector.children.appendData(attributeSelector);
             break;
           }
-
-          selector.children.insertData(attributeSelector, item.next);
           item = item?.next ?? null;
         }
+
+        if (itemsToInsertScopeBefore[currentChunkIndex]) {
+          itemsToInsertScopeBefore.pop();
+        }
+
+        itemsToInsertScopeBefore.forEach((scopePositionItem) => {
+          selector.children.insertData(attributeSelector, scopePositionItem);
+        });
       });
     });
 

--- a/src/css/scope-css.ts
+++ b/src/css/scope-css.ts
@@ -102,6 +102,7 @@ export function scopeCss(css: string, filename: string, hash: string) {
           item = item?.next ?? null;
         }
 
+        // This is true if one of the two break statements above was run. Which means we don't want to add to the last one.
         if (itemsToInsertScopeBefore[currentChunkIndex]) {
           itemsToInsertScopeBefore.pop();
         }


### PR DESCRIPTION
CSS Scoping:
Improved tests
 - Added more "categories" with describe so we can navigate the test file easier.
 - Added more tests to handle edge-cases around psudo-elements.

Improved scoping code
 - The logic for scoping was getting hard to read, made the logic easier to understand with less if statements.
 - Due to significant if statements we were loosing performance. I were hoping to improve performance with this fix. But it appears to be about the same. It might have improved it by a very small margin. 5%? We would need a real performance testing tool to statisticly assure the differance.